### PR TITLE
Refactor database query helper

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,13 +8,8 @@ const pool = new Pool({
     : false as any
 });
 
-// Support both: q`select ... ${x}`  and  q('select ... $1', [x])
-type Q = {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<any[]>;
-  (text: string, params?: any[]): Promise<any[]>;
-};
-
-export const q: Q = (async (strings: any, ...values: any[]) => {
+// Support both: q`select ... ${x}` and q('select ... $1', [x])
+export async function q(strings: TemplateStringsArray | string, ...values: any[]): Promise<any[]> {
   let text: string;
   let params: any[] = [];
 
@@ -36,9 +31,9 @@ export const q: Q = (async (strings: any, ...values: any[]) => {
     params = (values && values[0]) || [];
   }
 
-  const { rows } = await pool.query(text, params);
-  return rows;
-}) as Q;
+  const res = await pool.query(text, params);
+  return res.rows;
+}
 
 
 


### PR DESCRIPTION
## Summary
- simplify database query helper `q` to an async function
- ensure query rows are returned correctly without extra braces

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive prompt without ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68992814b5c08325bbcaefeeff9f9b8f