### PR TITLE
refactor: standardize task status and priority

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -7,7 +7,7 @@ const ALLOWED_PRIORITY = new Set(['low', 'medium', 'high']);
 /** GET /api/tasks/[id] */
 export async function GET(_req: Request, { params }: Ctx) {
   const { id } = params;
-  const { rows } = await q(
+  const rows = await q(
     `
     SELECT
       id,
@@ -53,7 +53,7 @@ export async function PATCH(req: Request, { params }: Ctx) {
     if (s === 'inactive' || s === 'active' || s === 'completed') status = s as any;
   }
 
-  const { rows } = await q(
+  const rows = await q(
     `
     UPDATE tasks
     SET
@@ -89,8 +89,10 @@ export async function PATCH(req: Request, { params }: Ctx) {
 /** DELETE /api/tasks/[id] */
 export async function DELETE(_req: Request, { params }: Ctx) {
   const { id } = params;
-  const { rowCount } = await q(`DELETE FROM tasks WHERE id = $1`, [id]);
-  return rowCount ? NextResponse.json({ ok: true }) : NextResponse.json({ error: 'not found' }, { status: 404 });
+  const rows = await q(`DELETE FROM tasks WHERE id = $1 RETURNING id`, [id]);
+  return rows[0]
+    ? NextResponse.json({ ok: true })
+    : NextResponse.json({ error: 'not found' }, { status: 404 });
 }
 
 

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -2,18 +2,7 @@
 
 import useSWR from 'swr';
 import { useState } from 'react';
-
-type Task = {
-  id: string;
-  title: string;
-  description: string | null;
-  category_id: string | null;
-  priority: 'low' | 'medium' | 'high' | null;
-  status?: 'inactive' | 'active' | 'completed';
-  created_at: string;
-  activated_at: string | null;
-  completed_at: string | null;
-};
+import type { Task } from '@/types';
 
 const fetcher = (u: string) => fetch(u).then(r => r.json());
 
@@ -23,8 +12,8 @@ export default function TasksPage() {
     title: '',
     description: '',
     category_id: '',
-    priority: 'medium' as 'low' | 'medium' | 'high',
-    status: 'inactive' as 'inactive' | 'active' | 'completed',
+    priority: 'medium' as Task['priority'],
+    status: 'inactive' as Task['status'],
   });
 
   async function addTask(e: React.FormEvent) {
@@ -49,7 +38,7 @@ export default function TasksPage() {
     }
   }
 
-  async function setStatus(id: string, status: 'inactive' | 'active' | 'completed') {
+  async function setStatus(id: string, status: Task['status']) {
     const prev = data || [];
     mutate(
       prev.map(t => (t.id === id ? { ...t, status } : t)),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,13 @@
 export type Task = {
-  id: string; title: string; description: string | null;
-  category_id: string | null; priority: 'low'|'medium'|'high'|'urgent';
-  status_select: 'inactive'|'active'|'completed';
-  created_at: string; activated_at: string | null; completed_at: string | null; updated_at: string;
+  id: string;
+  title: string;
+  description: string | null;
+  category_id: string | null;
+  priority: 'low' | 'medium' | 'high';
+  status: 'inactive' | 'active' | 'completed';
+  created_at: string;
+  activated_at: string | null;
+  completed_at: string | null;
+  updated_at: string;
   category_name?: string | null;
-}
+};


### PR DESCRIPTION
## Summary
- rename `status_select` to `status` on `Task`
- drop `urgent` priority and share `Task` type with tasks page
- update task API routes to expose `status` field and validate priority

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68992578c35083258d68f19f7dcda858