### PR TITLE
fix: return rows from queries

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -7,7 +7,7 @@ const ALLOWED_PRIORITY = new Set(['low', 'medium', 'high']);
 /** GET /api/tasks/[id] */
 export async function GET(_req: Request, { params }: Ctx) {
   const { id } = params;
-  const { rows } = await q(
+  const rows = await q(
     `
     SELECT
       id,
@@ -53,7 +53,7 @@ export async function PATCH(req: Request, { params }: Ctx) {
     if (s === 'inactive' || s === 'active' || s === 'completed') status = s as any;
   }
 
-  const { rows } = await q(
+  const rows = await q(
     `
     UPDATE tasks
     SET


### PR DESCRIPTION
## Summary
- return rows array directly from task queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899256ac9bc8325839ff5e1ff203eea