### PR TITLE
fix: preserve BigInt precision in JSON serialization

### DIFF
--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -3,7 +3,11 @@ export function toJSONSafe<T = any>(input: T): T {
     if (input === null || input === undefined) return input as any;
   
     const t = typeof input;
-    if (t === 'bigint') return Number(input) as any;
+    // Preserve BigInt precision: use a number when safe, otherwise stringify
+    if (t === 'bigint') {
+      const num = Number(input);
+      return Number.isSafeInteger(num) ? (num as any) : (input.toString() as any);
+    }
     if (t !== 'object') return input;
   
     if (input instanceof Date) return input.toISOString() as any;


### PR DESCRIPTION
## Summary
- avoid precision loss when serializing BigInt values by returning strings for unsafe integers

## Testing
- `node -r ts-node/register -e "const {toJSONSafe} = require('./src/lib/json'); console.log(toJSONSafe(9007199254740993n)); console.log(typeof toJSONSafe(9007199254740993n)); console.log(toJSONSafe(5n)); console.log(typeof toJSONSafe(5n));"`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689922c6437c8325a2a7b536a11e868c