### PR TITLE
Fix API routes for deals and interactions

### DIFF
--- a/src/app/api/cashflow/route.ts
+++ b/src/app/api/cashflow/route.ts
@@ -1,3 +1,6 @@
+import { NextResponse } from 'next/server';
+import { q } from '@/lib/db';
+
 export async function GET() {
   const summaryRows = await q`
     select

--- a/src/app/api/deals/[id]/route.ts
+++ b/src/app/api/deals/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(req: Request, { params }: Ctx) {
     'amount',
     'actual_amount',
     'stage',
-    'expected_close_date',
+    'expected_close_at',
     'notes',
   ];
 
@@ -36,7 +36,7 @@ export async function PATCH(req: Request, { params }: Ctx) {
   const sql = `UPDATE deals SET ${sets.join(', ')} WHERE id = $${i} RETURNING *;`;
   vals.push(id);
 
-  const { rows } = await q(sql, vals);
+  const rows = await q(sql, vals);
   if (!rows[0]) {
     return NextResponse.json({ error: 'Deal not found' }, { status: 404 });
   }

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -15,18 +15,18 @@ export async function GET(req: Request) {
 
   const sql = `
     SELECT id, prospect_id, name, amount, actual_amount, stage,
-           expected_close_date, created_at, updated_at, notes
+           expected_close_at, created_at, updated_at, notes
     FROM deals
     ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
     ORDER BY created_at DESC;
   `;
-  const { rows } = await q(sql, params);
+  const rows = await q(sql, params);
   return NextResponse.json(toJSONSafe(rows));
 }
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { prospect_id, name, amount, expected_close_date, notes } = body;
+  const { prospect_id, name, amount, expected_close_at, notes } = body;
 
   if (!prospect_id || !name) {
     return NextResponse.json(
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
   }
 
   const sql = `
-    INSERT INTO deals (prospect_id, name, amount, expected_close_date, notes)
+    INSERT INTO deals (prospect_id, name, amount, expected_close_at, notes)
     VALUES ($1, $2, $3, $4, $5)
     RETURNING *;
   `;
@@ -44,9 +44,9 @@ export async function POST(req: Request) {
     prospect_id,
     name,
     amount ?? null,
-    expected_close_date ?? null,
+    expected_close_at ?? null,
     notes ?? null,
   ];
-  const { rows } = await q(sql, params);
+  const rows = await q(sql, params);
   return NextResponse.json(toJSONSafe(rows[0]));
 }

--- a/src/app/api/prospect-interactions/route.ts
+++ b/src/app/api/prospect-interactions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { q } from '@/lib/db';
+import { toJSONSafe } from '@/lib/json';
 
 
 export async function GET(req: Request) {
@@ -14,8 +15,8 @@ export async function GET(req: Request) {
   }
   sql += ' ORDER BY created_at DESC';
 
-  const { rows } = await q(sql, vals.length ? vals : undefined);
-  return NextResponse.json(rows);
+  const rows = await q(sql, vals.length ? vals : undefined);
+  return NextResponse.json(toJSONSafe(rows));
 }
 
 export async function POST(req: Request) {
@@ -41,8 +42,8 @@ export async function POST(req: Request) {
     due_at ?? null,
   ];
 
-  const { rows } = await q(sql, params);
-  return NextResponse.json(rows[0]);
+  const rows = await q(sql, params);
+  return NextResponse.json(toJSONSafe(rows[0]));
 }
 
 


### PR DESCRIPTION
## Summary
- fix missing imports in cashflow route
- align deal endpoints with expected_close_at column and q helper
- normalize prospect interaction responses and ensure JSON-safe serialization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup; aborted)*
- `npm run build` *(partial output; build not completed)*

------
https://chatgpt.com/codex/tasks/task_e_689937c57d58832583815d465294ac07