### PR TITLE
Add migration for updated_at and notes in deals

### DIFF
--- a/sql/20240716_add_updated_at_and_notes_to_deals.sql
+++ b/sql/20240716_add_updated_at_and_notes_to_deals.sql
@@ -1,0 +1,17 @@
+-- Adds updated_at and notes columns to the deals table.
+-- This migration aligns the database schema with the API expectations.
+
+-- Add the columns if they do not exist.
+ALTER TABLE deals
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS notes TEXT;
+
+-- Backfill updated_at for existing rows using created_at.
+UPDATE deals
+SET updated_at = created_at
+WHERE updated_at IS NULL;
+
+-- Ensure updated_at always has a value and defaults to the current time.
+ALTER TABLE deals
+  ALTER COLUMN updated_at SET NOT NULL,
+  ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
## Summary
- add SQL migration to add updated_at and notes columns to deals table
## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompt to configure ESLint)

------
https://chatgpt.com/codex/tasks/task_e_68995757b3808325a47109a77a2d4746