### PR TITLE
Handle deal stage and probability

### DIFF
--- a/migrations/005_fix_deals_schema.sql
+++ b/migrations/005_fix_deals_schema.sql
@@ -1,0 +1,8 @@
+ALTER TABLE deals
+  ADD COLUMN IF NOT EXISTS probability double precision NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS stage text NOT NULL DEFAULT 'open',
+  ADD COLUMN IF NOT EXISTS heat text,
+  ADD COLUMN IF NOT EXISTS won_at timestamptz;
+
+UPDATE deals SET stage = 'open' WHERE stage IS NULL;
+UPDATE deals SET probability = 0 WHERE probability IS NULL;

--- a/src/app/api/deals/[id]/route.ts
+++ b/src/app/api/deals/[id]/route.ts
@@ -12,8 +12,11 @@ export async function PATCH(req: Request, { params }: Ctx) {
     'name',
     'amount',
     'actual_amount',
+    'probability',
     'stage',
     'expected_close_at',
+    'heat',
+    'won_at',
     'notes',
   ];
 
@@ -26,6 +29,11 @@ export async function PATCH(req: Request, { params }: Ctx) {
       sets.push(`${key} = $${i++}`);
       vals.push(body[key]);
     }
+  }
+
+  if (body.stage !== undefined && body.won_at === undefined) {
+    sets.push(`won_at = $${i++}`);
+    vals.push(body.stage === 'won' ? new Date().toISOString() : null);
   }
 
   if (sets.length === 0) {

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -14,8 +14,8 @@ export async function GET(req: Request) {
   }
 
   const sql = `
-    SELECT id, prospect_id, name, amount, actual_amount, stage,
-           expected_close_at, created_at, updated_at, notes
+    SELECT id, prospect_id, name, amount, actual_amount, probability, stage,
+           expected_close_at, won_at, heat, created_at, updated_at, notes
     FROM deals
     ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
     ORDER BY created_at DESC;
@@ -26,7 +26,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { prospect_id, name, amount, expected_close_at, notes } = body;
+  const { prospect_id, name, amount, probability, expected_close_at, heat, notes } = body;
 
   if (!prospect_id || !name) {
     return NextResponse.json(
@@ -36,15 +36,17 @@ export async function POST(req: Request) {
   }
 
   const sql = `
-    INSERT INTO deals (prospect_id, name, amount, expected_close_at, notes)
-    VALUES ($1, $2, $3, $4, $5)
+    INSERT INTO deals (prospect_id, name, amount, probability, stage, expected_close_at, heat, notes)
+    VALUES ($1, $2, $3, $4, 'open', $5, $6, $7)
     RETURNING *;
   `;
   const params = [
     prospect_id,
     name,
     amount ?? null,
+    probability ?? 0,
     expected_close_at ?? null,
+    heat ?? null,
     notes ?? null,
   ];
   const rows = await q(sql, params);

--- a/src/app/prospects/page.tsx
+++ b/src/app/prospects/page.tsx
@@ -321,7 +321,7 @@ export default function ProspectsPage() {
 
   async function markWon(id: string) {
     const actual = prompt('Actual amount collected? (leave blank to use proposed amount)');
-    const payload: any = { stage: 'won' };
+    const payload: any = { stage: 'won', won_at: new Date().toISOString() };
     if (actual && !isNaN(Number(actual))) payload.actual_amount = Number(actual);
     const res = await fetch(`/api/deals/${id}`, {
       method: 'PATCH',
@@ -336,7 +336,7 @@ export default function ProspectsPage() {
     const res = await fetch(`/api/deals/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ stage: 'lost', actual_amount: null }),
+      body: JSON.stringify({ stage: 'lost', actual_amount: null, won_at: null }),
     });
     if (!res.ok) return alert('Failed to mark lost');
     await refreshDeals();


### PR DESCRIPTION
## Summary
- persist probability and heat when creating deals and default new deals to an open stage
- allow updating probability, heat and stage while auto-setting won_at timestamps
- store won_at timestamps when marking deals won or lost
- add migration to ensure deals table has probability, stage, heat and won_at columns with defaults

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Property 'rows' does not exist on type 'any[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_6899ae8dae70832591cf2ee8ce78ccd6