### PR TITLE
Fix deal logging and visibility issues

### DIFF
--- a/src/app/api/deals/[id]/route.ts
+++ b/src/app/api/deals/[id]/route.ts
@@ -12,8 +12,10 @@ export async function PATCH(req: Request, { params }: Ctx) {
     'name',
     'amount',
     'actual_amount',
+    'probability',
     'stage',
     'expected_close_at',
+    'heat',
     'notes',
   ];
 
@@ -23,8 +25,20 @@ export async function PATCH(req: Request, { params }: Ctx) {
 
   for (const key of fields) {
     if (body[key] !== undefined) {
-      sets.push(`${key} = $${i++}`);
-      vals.push(body[key]);
+      if (key === 'stage') {
+        // Stage updates may adjust won_at automatically
+        sets.push(`stage = $${i}`);
+        vals.push(body[key]);
+        i++;
+        if (body[key] === 'won') {
+          sets.push(`won_at = NOW()`);
+        } else if (body[key] !== 'won') {
+          sets.push(`won_at = NULL`);
+        }
+      } else {
+        sets.push(`${key} = $${i++}`);
+        vals.push(body[key]);
+      }
     }
   }
 

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -14,8 +14,8 @@ export async function GET(req: Request) {
   }
 
   const sql = `
-    SELECT id, prospect_id, name, amount, actual_amount, stage,
-           expected_close_at, created_at, updated_at, notes
+    SELECT id, prospect_id, name, amount, actual_amount, probability, stage,
+           expected_close_at, won_at, heat, created_at, updated_at, notes
     FROM deals
     ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
     ORDER BY created_at DESC;
@@ -26,7 +26,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { prospect_id, name, amount, expected_close_at, notes } = body;
+  const { prospect_id, name, amount, probability, expected_close_at, heat, notes } = body;
 
   if (!prospect_id || !name) {
     return NextResponse.json(
@@ -36,15 +36,17 @@ export async function POST(req: Request) {
   }
 
   const sql = `
-    INSERT INTO deals (prospect_id, name, amount, expected_close_at, notes)
-    VALUES ($1, $2, $3, $4, $5)
+    INSERT INTO deals (prospect_id, name, amount, probability, stage, expected_close_at, heat, notes)
+    VALUES ($1, $2, $3, $4, 'open', $5, $6, $7)
     RETURNING *;
   `;
   const params = [
     prospect_id,
     name,
     amount ?? null,
+    probability ?? 0,
     expected_close_at ?? null,
+    heat ?? null,
     notes ?? null,
   ];
   const rows = await q(sql, params);


### PR DESCRIPTION
## Summary
- include probability, heat, and won date fields when listing deals
- store probability and heat on creation with stage defaulting to `open`
- allow updating probability, heat, and stage while tracking won date

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899ae8dae70832591cf2ee8ce78ccd6