### PR TITLE
Add migration and transaction schema fixes

### DIFF
--- a/db/migrations/2025-08-11_fix_deals_and_transactions.sql
+++ b/db/migrations/2025-08-11_fix_deals_and_transactions.sql
@@ -1,0 +1,90 @@
+-- Enable UUID helpers (safe if already installed)
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+------------------------------------------------------------
+-- Fix deals schema the API expects
+------------------------------------------------------------
+ALTER TABLE deals
+  ADD COLUMN IF NOT EXISTS notes       TEXT,
+  ADD COLUMN IF NOT EXISTS updated_at  TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Keep updated_at current on any update
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_trigger
+    WHERE  tgname = 'deals_set_updated_at'
+  ) THEN
+    CREATE OR REPLACE FUNCTION set_updated_at() RETURNS TRIGGER AS $f$
+    BEGIN
+      NEW.updated_at := now();
+      RETURN NEW;
+    END
+    $f$ LANGUAGE plpgsql;
+
+    CREATE TRIGGER deals_set_updated_at
+    BEFORE UPDATE ON deals
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at();
+  END IF;
+END$$;
+
+-- For existing rows created before updated_at existed, ensure it's not older than created_at
+UPDATE deals SET updated_at = GREATEST(updated_at, created_at);
+
+------------------------------------------------------------
+-- Create transactions table (used by /, /api/transactions, /api/cashflow)
+------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS transactions (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prospect_id   UUID NULL,
+  deal_id       UUID NULL,
+  type          TEXT NOT NULL CHECK (type IN ('income','expense')),
+  amount        NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
+  occurred_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  description   TEXT NULL,
+  category      TEXT NULL
+);
+
+-- Optional: wire FK’s if those tables exist (ignore if they don't)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name='prospects') THEN
+    ALTER TABLE transactions
+      DROP CONSTRAINT IF EXISTS transactions_prospect_id_fkey,
+      ADD  CONSTRAINT transactions_prospect_id_fkey
+      FOREIGN KEY (prospect_id) REFERENCES prospects(id) ON DELETE SET NULL;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name='deals') THEN
+    ALTER TABLE transactions
+      DROP CONSTRAINT IF EXISTS transactions_deal_id_fkey,
+      ADD  CONSTRAINT transactions_deal_id_fkey
+      FOREIGN KEY (deal_id) REFERENCES deals(id) ON DELETE SET NULL;
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_occurred_at ON transactions(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_transactions_type        ON transactions(type);
+CREATE INDEX IF NOT EXISTS idx_transactions_deal_id     ON transactions(deal_id);
+
+------------------------------------------------------------
+-- Backfill revenue transactions from already-won deals
+-- (so cashflow and home stop looking "empty")
+------------------------------------------------------------
+INSERT INTO transactions (deal_id, prospect_id, type, amount, occurred_at, description, category)
+SELECT
+  d.id,
+  d.prospect_id,
+  'income'::text,
+  COALESCE(NULLIF(d.actual_amount, 0), d.amount),     -- if you don’t have actual_amount this still works
+  COALESCE(NULLIF(d.won_at, TIMESTAMPTZ 'epoch'), d.updated_at, d.created_at),
+  d.name,
+  'deal'
+FROM deals d
+WHERE d.stage = 'won'
+  AND NOT EXISTS (
+    SELECT 1 FROM transactions t WHERE t.deal_id = d.id
+  );

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: Request) {
            expected_close_at, won_at, heat, created_at, updated_at, notes
     FROM deals
     ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(updated_at, created_at) DESC;
   `;
   const rows = await q(sql, params);
   return NextResponse.json(toJSONSafe(rows));

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -3,16 +3,36 @@ import { q } from '@/lib/db';
 import { toJSONSafe } from '@/lib/json';
 
 export async function GET() {
-  const rows = await q`SELECT id, amount, description, occurred_at, created_at FROM transactions ORDER BY occurred_at DESC`;
+  const rows = await q(
+    `
+    SELECT id, type, amount, occurred_at, description, category, deal_id, prospect_id
+    FROM transactions
+    ORDER BY occurred_at DESC
+    `
+  );
   return NextResponse.json(toJSONSafe(rows));
 }
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}));
   const amount = Number(body.amount);
-  if (Number.isNaN(amount)) return NextResponse.json({ error: 'Valid amount required' }, { status: 400 });
+  if (Number.isNaN(amount)) {
+    return NextResponse.json({ error: 'Valid amount required' }, { status: 400 });
+  }
+
+  const type = body.type === 'expense' ? 'expense' : 'income';
   const occurredAt = body.occurred_at ? new Date(body.occurred_at) : new Date();
   const description = body.description ? String(body.description) : null;
-  const rows = await q`INSERT INTO transactions (amount, description, occurred_at) VALUES (${amount}, ${description}, ${occurredAt}) RETURNING id, amount, description, occurred_at, created_at`;
+  const category = body.category ? String(body.category) : null;
+  const dealId = body.deal_id ? String(body.deal_id) : null;
+  const prospectId = body.prospect_id ? String(body.prospect_id) : null;
+
+  const sql = `
+    INSERT INTO transactions (type, amount, occurred_at, description, category, deal_id, prospect_id)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    RETURNING id, type, amount, occurred_at, description, category, deal_id, prospect_id;
+  `;
+  const params = [type, amount, occurredAt, description, category, dealId, prospectId];
+  const rows = await q(sql, params);
   return NextResponse.json(toJSONSafe(rows[0]));
 }

--- a/src/app/cashflow/page.tsx
+++ b/src/app/cashflow/page.tsx
@@ -21,9 +21,13 @@ type APIResponse = {
 
 type Transaction = {
   id: string;
+  type: 'income' | 'expense';
   amount: number;
   description: string | null;
   occurred_at: string;
+  category: string | null;
+  deal_id: string | null;
+  prospect_id: string | null;
 };
 
 const fetcher = async (u: string) => {
@@ -53,6 +57,7 @@ export default function CashflowPage() {
         amount: Number(tForm.amount),
         description: tForm.description || null,
         occurred_at: tForm.occurred_at || undefined,
+        type: 'income',
       }),
     });
     if (res.ok) {


### PR DESCRIPTION
## Summary
- add idempotent migration for deals and new transactions table, plus backfill
- adjust deals and transactions APIs for updated schema
- ensure cashflow creates income transactions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build` *(fails: Property 'rows' does not exist on type 'any[]')*
- `psql -f db/migrations/2025-08-11_fix_deals_and_transactions.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*


------
https://chatgpt.com/codex/tasks/task_e_6899b3f992b48325ad5ed7750262e889