### PR TITLE
Load env vars for migrations

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,6 +1,9 @@
 # Database Migrations
 
 Run these scripts against your PostgreSQL database to keep the schema in sync with the application.
+They rely on a `DATABASE_URL` environment variable, so ensure you have a
+`.env` file in the project root populated with your connection details
+before running them.
 
 The easiest way is to execute all outstanding migrations with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "personal-ops-app",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "next": "^14.2.31",
         "pg": "8.11.3",
         "react": "18.2.0",
@@ -1841,6 +1842,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "migrate": "node scripts/migrate.js"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "next": "^14.2.31",
     "pg": "8.11.3",
     "react": "18.2.0",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,3 +1,7 @@
+// Load environment variables from a .env file so migrations can
+// access database connection settings when run directly with Node.
+require('dotenv').config();
+
 const fs = require('fs');
 const path = require('path');
 const { Pool } = require('pg');


### PR DESCRIPTION
## Summary
- load environment variables in migration script via dotenv
- document that migrations depend on a DATABASE_URL and a .env file
- add dotenv dependency for scripts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)
- `npm run migrate` (fails: connect ECONNREFUSED ::1:5432)

------
https://chatgpt.com/codex/tasks/task_e_6899d23583948325bcffff55f94dace3